### PR TITLE
Fixed bug in netcdf compiler dependency

### DIFF
--- a/config/archer2-cse/packages.yaml
+++ b/config/archer2-cse/packages.yaml
@@ -39,7 +39,7 @@ packages:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-c@4.9.0.1+mpi%cee
+      - spec: netcdf-c@4.9.0.1+mpi%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
@@ -59,7 +59,7 @@ packages:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-fortran@4.9.0.1%cee
+      - spec: netcdf-fortran@4.9.0.1%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
@@ -80,7 +80,7 @@ packages:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-cxx4@4.9.0.1%cee
+      - spec: netcdf-cxx4@4.9.0.1%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
@@ -100,7 +100,7 @@ packages:
         modules:
           - cray-parallel-netcdf/1.12.3.1
         prefix: /opt/cray/pe/parallel-netcdf/1.12.3.1/gnu/9.1
-      - spec: parallel-netcdf@1.12.3.1%cee
+      - spec: parallel-netcdf@1.12.3.1%cce
         modules:
           - cray-parallel-netcdf/1.12.3.1
           - cray-netcdf-hdf5parallel 

--- a/config/archer2-user/packages.yaml
+++ b/config/archer2-user/packages.yaml
@@ -39,7 +39,7 @@ packages:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-c@4.9.0.1+mpi%cee
+      - spec: netcdf-c@4.9.0.1+mpi%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
@@ -59,7 +59,7 @@ packages:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-fortran@4.9.0.1%cee
+      - spec: netcdf-fortran@4.9.0.1%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
@@ -80,7 +80,7 @@ packages:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-cxx4@4.9.0.1%cee
+      - spec: netcdf-cxx4@4.9.0.1%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
@@ -100,7 +100,7 @@ packages:
         modules:
           - cray-parallel-netcdf/1.12.3.1
         prefix: /opt/cray/pe/parallel-netcdf/1.12.3.1/gnu/9.1
-      - spec: parallel-netcdf@1.12.3.1%cee
+      - spec: parallel-netcdf@1.12.3.1%cce
         modules:
           - cray-parallel-netcdf/1.12.3.1
           - cray-netcdf-hdf5parallel 


### PR DESCRIPTION
In the dependency the netcdf compiler is displayed as `cee` not `cce`.   
I have already made the changes on the cse installation.