### PR TITLE
Fine-tuning of the cse installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ spack -e environments/archer2-cse/ buildcache update-index cache
 
 ## Licensed packages
 
-Source code of licenced packages can be set in `archer2-cse/licensed_packages` . This directory is inonly accessible for the cse user.
+Source code of licenced packages can be set in `archer2-cse/licensed_packages` . This directory is only accessible for the cse user.
 A new licensed package tarball needs to be placed in `archer2-cse/licensed_packages/<my-package-name>`. 
 The mirror then needs to be built with 
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ module load PrgEnv-gnu
 
 ## Add packages
 
-Add a spec into the `environments/archer2-cse/spack.yaml` in the `$cse_specs` list. Then activate and re-install the environment
+- Add a spec into the `environments/archer2-cse/spack.yaml` in the `specs` list.
+- Install the new specs
 
 ```bash
-spack env activate environments/archer2-cse
-spack install
+spack -e  environments/archer2-cse install
 ```
 
 
@@ -104,6 +104,9 @@ The mirror then needs to be built with
 spack -e environments/archer2-cse/ mirror  create -d  archer2-cse/licensed_packages <my-package-name>
 spack -e environments/archer2-cse/ install -vvv <my-package-name>
 ```
+
+Once the package has been added to the mirror, it needs to be added to the environment, as described in the section above.
+However, make sure to set the permissions in the `packages` section of the `spack.yaml` environment.
 
 ## Build cache
 

--- a/README.md
+++ b/README.md
@@ -93,16 +93,6 @@ spack env activate environments/archer2-cse
 spack install
 ```
 
-## Pushing to the cache
-
-This pushes specs installed into the environment to a build cache.
-If a user installs the same spec, it will copy the binary from the cache instead of installing from scratch, saving build time.
-
-```bash
-spack -e environments/archer2-cse/ buildcache push --only=packages cache
-spack -e environments/archer2-cse/ buildcache push --only=dependencies cache
-spack -e environments/archer2-cse/ buildcache update-index cache
-```
 
 ## Licensed packages
 
@@ -114,3 +104,19 @@ The mirror then needs to be built with
 spack -e environments/archer2-cse/ mirror  create -d  archer2-cse/licensed_packages <my-package-name>
 spack -e environments/archer2-cse/ install -vvv <my-package-name>
 ```
+
+## Build cache
+
+Spack defaults to installing all packages from source. As this requires re-compiling, this can take a long time and/or require a large amount of memory.
+This can be sped up by setting a re-usable build cache of commonly used packages.
+An environment containg specs we want to cache is contained in the `archer2-cse-cache` environment.
+In order to add packages to the cache run
+
+```bash
+spack -e environments/archer2-cse-cache/ install # install specs defined in the environment
+spack -e environments/archer2-cse-cache/ buildcache push --only=package cache # Save defined specs in the build cache
+spack -e environments/archer2-cse-cache/ buildcache push --only=dependencies cache # Save dependencies in the build cache
+spack -e environments/archer2-cse-cache/ buildcache update-index cache # Update the cache index, so that the cached build can be found when an archer2 user installs the same package in their own environment
+```
+
+

--- a/README.md
+++ b/README.md
@@ -92,3 +92,14 @@ Add a spec into the `environments/archer2-cse/spack.yaml` in the `$cse_specs` li
 spack env activate environments/archer2-cse
 spack install
 ```
+
+## Pushing to the cache
+
+This pushes specs installed into the environment to a build cache.
+If a user installs the same spec, it will copy the binary from the cache instead of installing from scratch, saving build time.
+
+```bash
+spack -e environments/archer2-cse/ buildcache push --only=packages cache
+spack -e environments/archer2-cse/ buildcache push --only=dependencies cache
+spack -e environments/archer2-cse/ buildcache update-index cache
+```

--- a/README.md
+++ b/README.md
@@ -103,3 +103,14 @@ spack -e environments/archer2-cse/ buildcache push --only=packages cache
 spack -e environments/archer2-cse/ buildcache push --only=dependencies cache
 spack -e environments/archer2-cse/ buildcache update-index cache
 ```
+
+## Licensed packages
+
+Source code of licenced packages can be set in `archer2-cse/licensed_packages` . This directory is inonly accessible for the cse user.
+A new licensed package tarball needs to be placed in `archer2-cse/licensed_packages/<my-package-name>`. 
+The mirror then needs to be built with 
+
+```bash
+spack -e environments/archer2-cse/ mirror  create -d  archer2-cse/licensed_packages <my-package-name>
+spack -e environments/archer2-cse/ install -vvv <my-package-name>
+```

--- a/archer2-cse/licensed_packages/Readme.md
+++ b/archer2-cse/licensed_packages/Readme.md
@@ -1,0 +1,3 @@
+# Licensed packages
+
+Licensed packages should be placed in this directory using a structure of the form `<package_name>/<package_name>-<version>.tar.gz` .

--- a/config/archer2-user/mirrors.yaml
+++ b/config/archer2-user/mirrors.yaml
@@ -1,0 +1,6 @@
+mirrors:
+  cache:
+    url: $spack/../archer2-cse/cache
+    binary: true
+    source: false
+    signed: false

--- a/environments/archer2-cse-cache/spack.yaml
+++ b/environments/archer2-cse-cache/spack.yaml
@@ -5,13 +5,9 @@
 
 spack:
   
-  include: 
-    - $spack/../environments/archer2-cse/modules.yaml
-  
   specs:
     - python
     - openfoam%gcc
-    - castep%gcc
     - petsc %gcc@11.2.0
     - petsc %cce@15.0.0
     - petsc %aocc fortran=false
@@ -24,17 +20,8 @@ spack:
     unify: false
   config:
     install_tree:
-      root: $spack/../archer2-cse/opt
-      padding_length: 120
+      root: $spack/../archer2-cse/opt-cache
+      padding_length: 128
 
-  mirrors:
-    licensed_packages: $spack/../archer2-cse/licensed_packages
-
-  packages:
-    castep:
-      permissions:
-        write: user
-        read: group
-        group: castep
-
+  
   view: false

--- a/environments/archer2-cse/modules.yaml
+++ b/environments/archer2-cse/modules.yaml
@@ -1,0 +1,48 @@
+  modules:
+    default:
+      'enable:':
+      - lmod
+
+      use_view: false
+      roots:
+        lmod: $spack/../archer2-cse/modules
+      lmod:
+        projections:
+          all: '{name}/{version}'
+        gromacs:
+          environment:
+            set:
+              SLURM_CPU_FREQ_REQ: '2250000'
+        lammps:
+          environment:
+            set:
+              SLURM_CPU_FREQ_REQ: '2250000'
+
+
+
+        exclude:
+        - cray-mpich
+        - cray-libsci
+        - libfabric
+        - fftw
+        - hdf5
+        - cray-fftw
+        - parallel-netcdf
+        - netcdf-cxx4
+        - netcdf-fortran
+
+        hash_length: 0
+        core_compilers: [gcc@7.5.0]
+
+        hide_implicits: true
+        all:
+          autoload: direct
+        core_specs: [python]
+        'hierarchy:':
+        - compiler
+      arch_folder: false
+    prefix_inspections:
+      ./lib:
+      - LD_LIBRARY_PATH
+      ./lib64:
+      - LD_LIBRARY_PATH

--- a/environments/archer2-cse/spack.yaml
+++ b/environments/archer2-cse/spack.yaml
@@ -15,8 +15,6 @@ spack:
     - gromacs%gcc@11.2.0
     - gromacs%cce
     - lammps%gcc@11.2.0
-    - castep%gcc
-
 
   modules:
     default:
@@ -71,6 +69,7 @@ spack:
   specs:
   - $cse_specs
 
+  - openfoam-org%gcc
   concretizer:
     unify: false
   config:

--- a/environments/archer2-cse/spack.yaml
+++ b/environments/archer2-cse/spack.yaml
@@ -8,12 +8,14 @@ spack:
   - cse_specs:
     - python
     - openfoam%gcc
+    - castep%gcc
     - petsc %gcc@11.2.0
     - petsc %cce@15.0.0
     - petsc %aocc fortran=false
     - gromacs%gcc@11.2.0
     - gromacs%cce
     - lammps%gcc@11.2.0
+    - castep%gcc
 
 
   modules:
@@ -27,17 +29,16 @@ spack:
       lmod:
         projections:
           all: '{name}/{version}'
-        
         gromacs:
-          environment: 
+          environment:
             set:
-              SLURM_CPU_FREQ_REQ: "2250000"
+              SLURM_CPU_FREQ_REQ: '2250000'
         lammps:
-          environment: 
+          environment:
             set:
-              SLURM_CPU_FREQ_REQ: "2250000"
-        
-        
+              SLURM_CPU_FREQ_REQ: '2250000'
+
+
 
         exclude:
         - cray-mpich
@@ -76,5 +77,14 @@ spack:
     install_tree:
       root: $spack/../archer2-cse/opt
 
+  mirrors:
+    licensed_packages: $spack/../archer2-cse/licensed_packages
+
+  packages:
+    castep:
+      permissions:
+        write: user
+        read: group
+        group: castep
 
   view: false

--- a/scripts/tools/templates/cse_modules.template.lua
+++ b/scripts/tools/templates/cse_modules.template.lua
@@ -32,9 +32,29 @@ if os.getenv("PE_ENV") == "GNU" then
     prepend_path("MODULEPATH", aocc_path)
 end
 
-prepend_path("LMOD_CUSTOM_COMPILER_GNU_PREFIX", gnu_path)
-prepend_path("LMOD_CUSTOM_COMPILER_GNU_8_0_PREFIX", gnu_path )
-prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_PREFIX", cray_path )
-prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_10_0_PREFIX", cray_path)
-prepend_path("LMOD_CUSTOM_COMPILER_AOCC_PREFIX", aocc_path)
-prepend_path("LMOD_CUSTOM_COMPILER_AOCC_3_0_PREFIX", aocc_path )
+pushenv("LMOD_CUSTOM_COMPILER_GNU_PREFIX", gnu_path)
+pushenv("LMOD_CUSTOM_COMPILER_GNU_8_0_PREFIX", gnu_path )
+pushenv("LMOD_CUSTOM_COMPILER_CRAYCLANG_PREFIX", cray_path )
+pushenv("LMOD_CUSTOM_COMPILER_CRAYCLANG_10_0_PREFIX", cray_path)
+pushenv("LMOD_CUSTOM_COMPILER_AOCC_PREFIX", aocc_path)
+pushenv("LMOD_CUSTOM_COMPILER_AOCC_3_0_PREFIX", aocc_path)
+
+
+-- Removing the current software spack from the modules to avoid clashes and recreating some of the environment. 
+-- In the future we might want to separate these module path from other variables in epcc-setup-env in order to avoid the duplication.
+
+unload("epcc-setup-env")
+
+
+-- Set any env vars
+setenv("EPCC_SOFTWARE_DIR","/mnt/lustre/a2fs-work4/work/y07/shared")
+setenv("SLURM_CPU_FREQ_REQ","2000000")
+setenv("SBATCH_EXPORT", "SLURM_CPU_FREQ_REQ,SBATCH_EXPORT")
+setenv("SLURM_EXPORT_ENV", "all")
+setenv("EPCC_SINGULARITY_DIR", "/work/y07/shared/singularity-images")
+
+
+
+-- Aliases
+local bashStr = "lfs quota -hp $(lsattr -p . | head -1 | awk '{print $1}') ."
+set_shell_function('showquota', bashStr, bashStr)

--- a/scripts/tools/templates/cse_modules.template.lua
+++ b/scripts/tools/templates/cse_modules.template.lua
@@ -24,7 +24,6 @@ local cray_path = pathJoin(softwarebase, "cce/15.0.0")
 local aocc_path = pathJoin(softwarebase, "aocc/4.0.0")
 local core_path = pathJoin(softwarebase, "Core")
 
-
 if os.getenv("PE_ENV") == "GNU" then
     prepend_path("MODULEPATH", gnu_path)
   elseif os.getenv("PE_ENV") == "CRAY" then

--- a/scripts/tools/templates/cse_modules.template.lua
+++ b/scripts/tools/templates/cse_modules.template.lua
@@ -22,6 +22,7 @@ local softwarebase = "__EPCC__SPACK__REPO__ROOT__/archer2-cse/modules"
 local gnu_path = pathJoin(softwarebase, "gcc/11.2.0")
 local cray_path = pathJoin(softwarebase, "cce/15.0.0")
 local aocc_path = pathJoin(softwarebase, "aocc/4.0.0")
+local core_path = pathJoin(softwarebase, "Core")
 
 
 if os.getenv("PE_ENV") == "GNU" then
@@ -32,18 +33,19 @@ if os.getenv("PE_ENV") == "GNU" then
     prepend_path("MODULEPATH", aocc_path)
 end
 
+prepend_path("MODULEPATH", core_path)
+
+-- Removing the current software spack from the modules to avoid clashes and recreating some of the environment. 
+-- In the future we might want to separate these module path from other variables in epcc-setup-env in order to avoid the duplication.
+
+unload("epcc-setup-env")
+
 pushenv("LMOD_CUSTOM_COMPILER_GNU_PREFIX", gnu_path)
 pushenv("LMOD_CUSTOM_COMPILER_GNU_8_0_PREFIX", gnu_path )
 pushenv("LMOD_CUSTOM_COMPILER_CRAYCLANG_PREFIX", cray_path )
 pushenv("LMOD_CUSTOM_COMPILER_CRAYCLANG_10_0_PREFIX", cray_path)
 pushenv("LMOD_CUSTOM_COMPILER_AOCC_PREFIX", aocc_path)
 pushenv("LMOD_CUSTOM_COMPILER_AOCC_3_0_PREFIX", aocc_path)
-
-
--- Removing the current software spack from the modules to avoid clashes and recreating some of the environment. 
--- In the future we might want to separate these module path from other variables in epcc-setup-env in order to avoid the duplication.
-
-unload("epcc-setup-env")
 
 
 -- Set any env vars


### PR DESCRIPTION
This pull request mainly aims toallow integration of the cse module system with reframe. 
Changes:
- Changes to the cse_env module to avoid clashes with currently installed software stack
- Setting up a build cache, to avoid re-building from source multiple times during development/testing. Packages to go into the build cache are in a separate environment `archer2-cse-cache`. This is because the packages in the cache might be different from the cse supported packages: unsopported packages might be added here and licensed packages should not be cached for security reasons. 
- Adding an example and documentation on how to add a licensed package. Castep is added to the environment to provide ad example