### PR TITLE
Fix package paths for 2025-10-26 ARCHER2 update

### DIFF
--- a/config/archer2-user/packages.yaml
+++ b/config/archer2-user/packages.yaml
@@ -41,6 +41,7 @@ packages:
             cxx: CC
             fortran: ftn
         modules:
+          - cpe/23.09
           - PrgEnv-gnu
           - gcc/11.2.0
           - xpmem
@@ -63,6 +64,7 @@ packages:
             cxx: CC
             fortran: ftn
         modules:
+          - cpe/23.09
           - PrgEnv-cray
           - cce/16.0.1
           - xpmem
@@ -78,6 +80,7 @@ packages:
             cxx: CC
             fortran: ftn
         modules:
+          - cpe/23.09
           - PrgEnv-aocc
           - aocc/4.0.0
           - xpmem

--- a/config/archer2-user/packages.yaml
+++ b/config/archer2-user/packages.yaml
@@ -56,7 +56,7 @@ packages:
   
   cce:
     externals:
-      - spec: cce@=15.0.0
+      - spec: cce@=16.0.1
         extra_attributes:
           compilers:
             c: cc
@@ -64,7 +64,7 @@ packages:
             fortran: ftn
         modules:
           - PrgEnv-cray
-          - cce/15.0.0
+          - cce/16.0.1
           - xpmem
           - libfabric
           - craype-x86-rome
@@ -84,134 +84,118 @@ packages:
           - libfabric
           - craype-x86-rome
           - craype-network-ofi
-        
-      
-        
+
+
   netcdf-c:
     externals:
-      - spec: netcdf-c@4.9.0.1+mpi%gcc
+      - spec: netcdf-c@4.9.0.7+mpi%gcc
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-c@4.9.0.1+mpi%cce
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/gnu/9.1
+      - spec: netcdf-c@4.9.0.7+mpi%cce
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
-      - spec: netcdf-c@4.9.0.1+mpi%aocc
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/crayclang/14.0
+      - spec: netcdf-c@4.9.0.7+mpi%aocc
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/aocc/3.0
-    
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/aocc/3.2
     buildable: False
 
   netcdf-fortran:
     externals:
-      - spec: netcdf-fortran@4.9.0.1%gcc
+      - spec: netcdf-fortran@4.9.0.7%gcc
+        modules:
+          - cray-hdf5-parallel/1.12.2.7
+          - cray-netcdf-hdf5parallel 
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/gnu/9.1
+      - spec: netcdf-fortran@4.9.0.7%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-fortran@4.9.0.1%cce
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/crayclang/14.0
+      - spec: netcdf-fortran@4.9.0.7%aocc
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
-
-      - spec: netcdf-fortran@4.9.0.1%aocc
-        modules:
-          - cray-hdf5-parallel/1.12.2.1
-          - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/aocc/3.0
-      
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/aocc/3.2
     buildable: False
 
   netcdf-cxx4:
     externals:
-      - spec: netcdf-cxx4@4.9.0.1%gcc
+      - spec: netcdf-cxx4@4.9.0.7%gcc
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1
-      - spec: netcdf-cxx4@4.9.0.1%cce
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/gnu/9.1
+      - spec: netcdf-cxx4@4.9.0.7%cce
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
-      - spec: netcdf-cxx4@4.9.0.1%aocc
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/crayclang/14.0
+      - spec: netcdf-cxx4@4.9.0.7%aocc
         modules:
-          - cray-hdf5-parallel/1.12.2.1
+          - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/aocc/3.0
-    
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/aocc/3.2
     buildable: False
-
 
   parallel-netcdf:
     externals:
-      - spec: parallel-netcdf@1.12.3.1%gcc
+      - spec: parallel-netcdf@1.12.3.7%gcc
         modules:
-          - cray-parallel-netcdf/1.12.3.1
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.1/gnu/9.1
-      - spec: parallel-netcdf@1.12.3.1%cce
+          - cray-parallel-netcdf/1.12.3.7
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/gnu/9.1
+      - spec: parallel-netcdf@1.12.3.7%cce
         modules:
-          - cray-parallel-netcdf/1.12.3.1
-          - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.1/crayclang/14.0
-      - spec: parallel-netcdf@1.12.3.1%aocc
+          - cray-parallel-netcdf/1.12.3.7
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/crayclang/14.0
+      - spec: parallel-netcdf@1.12.3.7%aocc
         modules:
-          - cray-parallel-netcdf/1.12.3.1
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.1/aocc/3.0
-    
+          - cray-parallel-netcdf/1.12.3.7
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/aocc/3.2
     buildable: False
 
   cray-mpich:
     externals:
-    - spec: cray-mpich@8.1.23 +wrappers %gcc 
+    - spec: cray-mpich@8.1.27 +wrappers %gcc
       modules:
-      - cray-mpich/8.1.23
+      - cray-mpich/8.1.27
       - craype-network-ofi
-      prefix: /opt/cray/pe/mpich/8.1.23/ofi/gnu/9.1  
-    
-    - spec: cray-mpich@8.1.23 +wrappers   %aocc
+      prefix: /opt/cray/pe/mpich/8.1.27/ofi/gnu/9.1
+    - spec: cray-mpich@8.1.27 +wrappers %cce
       modules:
-      - cray-mpich/8.1.23
+      - cray-mpich/8.1.27
       - craype-network-ofi
-      prefix: /opt/cray/pe/mpich/8.1.23/ofi/aocc/3.0
-    - spec: cray-mpich@8.1.23 +wrappers %cce
+      prefix: /opt/cray/pe/mpich/8.1.27/ofi/crayclang/14.0
+    - spec: cray-mpich@8.1.27 +wrappers %aocc
       modules:
-      - cray-mpich/8.1.23
+      - cray-mpich/8.1.27
       - craype-network-ofi
-      prefix: /opt/cray/pe/mpich/8.1.23/ofi/cray/10.0
+      prefix: /opt/cray/pe/mpich/8.1.27/ofi/aocc/3.0
     buildable: false
-
   
-
   hdf5:
     externals:
-      - spec: hdf5@1.12.2.1+mpi%gcc
+      - spec: hdf5@1.12.2.7+mpi%gcc
         modules:
-          - cray-mpich/8.1.23
-          - cray-hdf5-parallel/1.12.2.1 
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.1/gnu/9.1
-      
-      - spec: hdf5@1.12.2.1+mpi%cce
+          - cray-mpich/8.1.27
+          - cray-hdf5-parallel/1.12.2.7
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.7/gnu/9.1
+      - spec: hdf5@1.12.2.7+mpi%cce
         modules:
-          - cray-mpich/8.1.23
-          - cray-hdf5-parallel/1.12.2.1 
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.1/crayclang/14.0
-
-      - spec: hdf5@1.12.2.1+mpi%aocc
+          - cray-mpich/8.1.27
+          - cray-hdf5-parallel/1.12.2.7
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.7/crayclang/14.0
+      - spec: hdf5@1.12.2.7+mpi%aocc
         modules:
-          - cray-mpich/8.1.23
-          - cray-hdf5-parallel/1.12.2.1 
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.1/aocc/3.0
-      
-
+          - cray-mpich/8.1.27
+          - cray-hdf5-parallel/1.12.2.7
+        prefix: /opt/cray/pe/mpich/8.1.27/ofi/aocc/3.0
     buildable: False
-
 
   pkg-config:
     externals:
@@ -224,72 +208,66 @@ packages:
     - spec: libfabric@1.12.1.2.2.0.0
       modules:
       - libfabric/1.12.1.2.2.0.0
-      prefix: /opt/cray/libfabric/1.11.0.4.128
+      prefix: /opt/cray/libfabric/1.12.1.2.2.0.0
     buildable: false
 
   cray-fftw:
     externals:
-    - spec: cray-fftw@3.3.10.3
+    - spec: cray-fftw@3.3.10.5
       modules:
       - craype-x86-rome
-      - cray-fftw/3.3.10.3
-      prefix: /opt/cray/pe/fftw/3.3.10.3/x86_rome
+      - cray-fftw/3.3.10.5
+      prefix: /opt/cray/pe/fftw/3.3.10.5/x86_rome
     buildable: false
-
 
   cray-libsci:
     externals:
-    - spec: cray-libsci@22.12.1.1%gcc
+    - spec: cray-libsci@23.09.1.1%gcc
       modules:
-      - cray-libsci/22.12.1.1
-      prefix: /opt/cray/pe/libsci/22.12.1.1/GNU/9.1/x86_64
-    - spec: cray-libsci@21.08.1.2%cce
+      - cray-libsci/23.09.1.1
+      prefix: /opt/cray/pe/libsci/23.09.1.1/GNU/10.3/x86_64
+    - spec: cray-libsci@23.09.1.1%cce
       modules:
-      - cray-libsci/22.12.1.1
-      prefix: /opt/cray/pe/libsci/22.12.1.1/CRAY/9.0/x86_64
+      - cray-libsci/23.09.1.1
+      prefix: /opt/cray/pe/libsci/23.09.1.1/CRAY/12.0/x86_64
     - spec: cray-libsci@22.08.1.1%aocc
       modules:
       - cray-libsci/22.12.1.1
-      prefix: /opt/cray/pe/libsci/22.12.1.1/AOCC/2.0/x86_64
+      prefix: /opt/cray/pe/libsci/23.09.1.1/AOCC/3.2/x86_64
  
-
   python:
     externals:
-     - spec: python@3.9.13.1
-
-       prefix: /opt/cray/pe/python/3.9.13.1
+     - spec: python@3.10.10
+       prefix: /opt/cray/pe/python/3.10.10
   
   py-numpy:
     externals:
-     - spec: py-numpy@1.21.5
-       prefix:  /opt/cray/pe/python/3.9.13.1
+     - spec: py-numpy@1.23.5
+       prefix: /opt/cray/pe/python/3.10.10
   
-
   py-mpi4py:
     externals:
-     - spec: py-mpi4py@3.1.3
-       prefix:  /opt/cray/pe/python/3.9.13.1
+     - spec: py-mpi4py@3.1.4
+       prefix: /opt/cray/pe/python/3.10.10
     buildable: false
     
   py-scipy:
     externals:
-     - spec: py-scipy@1.6.2
-       prefix:  /opt/cray/pe/python/3.9.13.1
+     - spec: py-scipy@1.10.0
+       prefix: /opt/cray/pe/python/3.10.10
     
-  
   py-cython:
     externals:
-     - spec: py-cython@0.29.28
-
-       prefix:  /opt/cray/pe/python/3.9.13.1
+     - spec: py-cython@0.29.36
+       prefix: /opt/cray/pe/python/3.10.10
   
   py-setuptools:
     externals:
-     - spec: py-setuptools@58.1.0
-       prefix:  /opt/cray/pe/python/3.9.13.1
+     - spec: py-setuptools@65.5.0
+       prefix: /opt/cray/pe/python/3.10.10
   
   py-setuptools-scm:
     externals:
-     - spec: py-setuptools-scm@6.0.1
-       prefix:  /opt/cray/pe/python/3.9.13.1
-  
+     - spec: py-setuptools-scm@7.1.0
+       prefix: /opt/cray/pe/python/3.10.10
+


### PR DESCRIPTION
The 2025-10-26 update to ARCHER2 changed the default CPE version and the locations of some packages such as libfabric. The package paths need to be fixed following the update.

Along the way I also rationalised some of the package entries (such as compiler order GCC > Cray > AOCC) and did a little linting.