### PR TITLE
New SPACK_BASE environment variable in Spack module

### DIFF
--- a/scripts/tools/templates/spack.template.lua
+++ b/scripts/tools/templates/spack.template.lua
@@ -11,10 +11,11 @@ user's directories at
 
 local pkgBase = "__EPCC__SPACK__REPO__ROOT__"
 
-local pkgConfigBase= pathJoin( pkgBase, "config","archer2-user")
+local pkgConfigBase= pathJoin(pkgBase, "config","archer2-user")
 
--- Sets the root of the spack installation location.
+-- Sets the base and root of the Spack installation location.
 
+setenv("SPACK_BASE", pkgBase)
 setenv("SPACK_ROOT", pathJoin(pkgBase,"spack") )
 
 -- This is the user level package which will cache to a directory called .spack


### PR DESCRIPTION
While updating the documentation, Arno spotted that the given path to the ARCHER2 package repos didn't work. Using `SPACK_ROOT`, it would have needed

```
$SPACK_ROOT../repos/archer2/spack_repo/archer2
```

because `SPACK_ROOT` refers to the Spack installation itself, rather than our clone of `archer2-spack` which contains it.

I've fixed the module on ARCHER2 and the documentation to instead use a new environment variable `SPACK_BASE` which refers not to Spack itself but to that `archer2-spack` location, so users can now use the nicer

```
$SPACK_BASE/repos/archer2/spack_repo/archer2
```

If we ever need to work outside Lmod with anything else not in Spack itself but in our own configs, this also makes it that tiny bit easier to access it.

This PR makes the same change in the template modulefile, so any time that we automatically generate the modulefile from now on it will include the change to set `SPACK_BASE`.