### PR TITLE
Changed default behavior for module generation

### DIFF
--- a/config/archer2-user/modules.yaml
+++ b/config/archer2-user/modules.yaml
@@ -1,0 +1,36 @@
+modules:
+  default:
+    enable::
+      - lmod
+    roots:
+      lmod: $env/modules
+    lmod:
+      hash_length: 0
+      hierarchy:: [] # Disable using mpi hierarchy
+      core_compilers: [gcc,cce] # Disable using compiler hierarchy
+      hide_implicits: true
+      all:
+        autoload: run
+      projections:
+        all: '{name}/{version}-{compiler.name}'
+      exclude:
+        - netcdf-c
+        - netcdf-fortran
+        - netcdf-cxx4
+        - parallel-netcdf
+        - cray-mpich
+        - hdf5
+        - libfabric
+        - cray-fftw
+        - cray-libsci
+    arch_folder: false
+  
+  prefix_inspections:
+    ./lib:
+      - LD_LIBRARY_PATH
+      - LIBRARY_PATH
+    ./lib64:
+      - LD_LIBRARY_PATH
+      - LIBRARY_PATH
+    ./include:
+      - CPATH

--- a/config/archer2-user/modules.yaml
+++ b/config/archer2-user/modules.yaml
@@ -3,7 +3,7 @@ modules:
     enable::
       - lmod
     roots:
-      lmod: $env/modules
+      lmod: $user_cache_path/share/spack/modules
     lmod:
       hash_length: 0
       hierarchy:: [] # Disable using mpi hierarchy


### PR DESCRIPTION
This is a similar change the PR for Cirrus-ex (https://github.com/EPCCed/cirrus-ex-spack/pull/39) enabling users to create module files in their local spack environment.

Following is an example flow the users can follow:

```bash
module load other-software
module load spack
spack env create -d my_test_env
spack env activate my_test_env
spack add gromacs %gcc
spack install 
spack module lmod refresh --delete-tree -y
module use $SPACK_USER_CONFIG_PATH/share/spack/modules/Core
module load gromacs
```

By default the module files are created in `$SPACK_USER_CONFIG_PATH/share/spack/modules/Core`. To change this, the user can use the following command and create the module files again:

```bash
spack config add "modules:default:roots:lmod:<full_path_to_modulefiles>"
spack module lmod refresh --delete-tree -y
```

To verify the path:

```bash
spack config get modules | grep "lmod: "
```