### PR TITLE
Change compilers in paths to uppercase for external cray packages

### DIFF
--- a/config/archer2-user/packages.yaml
+++ b/config/archer2-user/packages.yaml
@@ -95,17 +95,17 @@ packages:
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/gnu/9.1
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/GNU/9.1
       - spec: netcdf-c@4.9.0.7+mpi%cce
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/crayclang/14.0
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/CRAYCLANG/14.0
       - spec: netcdf-c@4.9.0.7+mpi%aocc
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/aocc/3.2
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/AOCC/3.2
     buildable: False
 
   netcdf-fortran:
@@ -114,17 +114,17 @@ packages:
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/gnu/9.1
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/GNU/9.1
       - spec: netcdf-fortran@4.9.0.7%cce
         modules:
           - cray-hdf5-parallel/1.12.2.1
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/crayclang/14.0
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/CRAYCLANG/14.0
       - spec: netcdf-fortran@4.9.0.7%aocc
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/aocc/3.2
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/AOCC/3.2
     buildable: False
 
   netcdf-cxx4:
@@ -133,17 +133,17 @@ packages:
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/gnu/9.1
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/GNU/9.1
       - spec: netcdf-cxx4@4.9.0.7%cce
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/crayclang/14.0
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/CRAYCLANG/14.0
       - spec: netcdf-cxx4@4.9.0.7%aocc
         modules:
           - cray-hdf5-parallel/1.12.2.7
           - cray-netcdf-hdf5parallel 
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/aocc/3.2
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.7/AOCC/3.2
     buildable: False
 
   parallel-netcdf:
@@ -151,15 +151,15 @@ packages:
       - spec: parallel-netcdf@1.12.3.7%gcc
         modules:
           - cray-parallel-netcdf/1.12.3.7
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/gnu/9.1
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/GNU/9.1
       - spec: parallel-netcdf@1.12.3.7%cce
         modules:
           - cray-parallel-netcdf/1.12.3.7
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/crayclang/14.0
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/CRAYCLANG/14.0
       - spec: parallel-netcdf@1.12.3.7%aocc
         modules:
           - cray-parallel-netcdf/1.12.3.7
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/aocc/3.2
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.7/AOCC/3.2
     buildable: False
 
   cray-mpich:
@@ -168,17 +168,17 @@ packages:
       modules:
       - cray-mpich/8.1.27
       - craype-network-ofi
-      prefix: /opt/cray/pe/mpich/8.1.27/ofi/gnu/9.1
+      prefix: /opt/cray/pe/mpich/8.1.27/ofi/GNU/9.1
     - spec: cray-mpich@8.1.27 +wrappers %cce
       modules:
       - cray-mpich/8.1.27
       - craype-network-ofi
-      prefix: /opt/cray/pe/mpich/8.1.27/ofi/crayclang/14.0
+      prefix: /opt/cray/pe/mpich/8.1.27/ofi/CRAYCLANG/14.0
     - spec: cray-mpich@8.1.27 +wrappers %aocc
       modules:
       - cray-mpich/8.1.27
       - craype-network-ofi
-      prefix: /opt/cray/pe/mpich/8.1.27/ofi/aocc/3.0
+      prefix: /opt/cray/pe/mpich/8.1.27/ofi/AOCC/3.0
     buildable: false
   
   hdf5:
@@ -187,17 +187,17 @@ packages:
         modules:
           - cray-mpich/8.1.27
           - cray-hdf5-parallel/1.12.2.7
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.7/gnu/9.1
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.7/GNU/9.1
       - spec: hdf5@1.12.2.7+mpi%cce
         modules:
           - cray-mpich/8.1.27
           - cray-hdf5-parallel/1.12.2.7
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.7/crayclang/14.0
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.7/CRAYCLANG/14.0
       - spec: hdf5@1.12.2.7+mpi%aocc
         modules:
           - cray-mpich/8.1.27
           - cray-hdf5-parallel/1.12.2.7
-        prefix: /opt/cray/pe/mpich/8.1.27/ofi/aocc/3.0
+        prefix: /opt/cray/pe/mpich/8.1.27/ofi/AOCC/3.0
     buildable: False
 
   pkg-config:


### PR DESCRIPTION
The cray compiler wrappers can break if the prefix paths for external packages use lowercase compiler names.

To replicate the current error, you can run:
```
module load PrgEnv-gnu
module load other-software
module load spack
spack install cray-mpich
spack load cray-mpich
ftn hello.F90
```

Where `hello.F90` is a simple test program:
```
program hello
  use mpi

  print *, 'Hello, World!'
end program hello
```